### PR TITLE
fix: build:win:noSign error

### DIFF
--- a/scripts/baseConfig.ts
+++ b/scripts/baseConfig.ts
@@ -1,0 +1,72 @@
+import { Configuration } from 'electron-builder';
+
+import { COMMON_APP_CONFIG } from '../src/environment';
+
+export const ELECTRON_BUILD_CONFIG: Configuration = {
+  appId: '.postcat.io',
+  productName: 'Postcat',
+  asar: true,
+  directories: {
+    output: 'release/'
+  },
+  files: [
+    'out/app/**/*.js*',
+    'out/platform/**/*.js*',
+    'out/environment.js',
+    'out/shared/**/*.js*',
+    'src/browser/dist/**/*',
+    'out/browser/src/**/*.js*',
+    'out/node/test-server/**/*.js*',
+    'out/app/common/**/*',
+    '!**/*.ts'
+  ],
+  publish: [
+    'github',
+    {
+      provider: 'generic',
+      url: COMMON_APP_CONFIG.BASE_DOWNLOAD_URL
+    }
+  ],
+  generateUpdatesFilesForAllChannels: true,
+  nsis: {
+    // 指定guid，此guid会存放在注册表中，如果没有指定则系统会自动生成
+    guid: 'Postcat',
+    oneClick: false,
+    allowElevation: true,
+    allowToChangeInstallationDirectory: true,
+    // for win - 将协议写入主机的脚本
+    include: 'scripts/urlProtoco.nsh'
+  },
+  protocols: [
+    // for macOS - 用于在主机注册指定协议
+    {
+      name: 'eoapi',
+      schemes: ['eoapi']
+    }
+  ],
+  portable: {
+    splashImage: 'src/app/common/images/postcat.bmp'
+  },
+  dmg: {
+    sign: false
+  },
+  afterSign: 'scripts/notarize.js',
+  linux: {
+    icon: 'src/app/common/images/',
+    target: ['AppImage']
+  },
+  mac: {
+    icon: 'src/app/common/images/512x512.png',
+    hardenedRuntime: true,
+    category: 'public.app-category.productivity',
+    gatekeeperAssess: false,
+    entitlements: 'scripts/entitlements.mac.plist',
+    entitlementsInherit: 'scripts/entitlements.mac.plist',
+    target: [
+      {
+        target: 'default',
+        arch: ['x64', 'arm64']
+      }
+    ]
+  }
+};

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,16 +1,16 @@
-import { sign, doSign } from 'app-builder-lib/out/codeSign/windowsCodeSign';
-import { build, BuildResult, Platform } from 'electron-builder';
+import { doSign, sign } from 'app-builder-lib/out/codeSign/windowsCodeSign';
 import type { Configuration } from 'electron-builder';
+import { Platform, build } from 'electron-builder';
 import minimist from 'minimist';
 import YAML from 'yaml';
 
 import pkgInfo from '../package.json';
-import { COMMON_APP_CONFIG } from '../src/environment';
+import { ELECTRON_BUILD_CONFIG } from './baseConfig';
 
-import { execSync, exec, spawn } from 'node:child_process';
+import { exec, execSync, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { copyFileSync, createReadStream, readFileSync, writeFileSync } from 'node:fs';
-import path, { resolve } from 'node:path';
+import { createReadStream, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { exit, platform } from 'node:process';
 
 const pkgPath = path.join(__dirname, '../package.json');
@@ -52,74 +52,7 @@ function hashFile(file: string, algorithm = 'sha512', encoding: 'base64' | 'hex'
       .pipe(hash, { end: false });
   });
 }
-export const ELECTRON_BUILD_CONFIG: Configuration = {
-  appId: '.postcat.io',
-  productName: 'Postcat',
-  asar: true,
-  directories: {
-    output: 'release/'
-  },
-  files: [
-    'out/app/**/*.js*',
-    'out/platform/**/*.js*',
-    'out/environment.js',
-    'out/shared/**/*.js*',
-    'src/browser/dist/**/*',
-    'out/browser/src/**/*.js*',
-    'out/node/test-server/**/*.js*',
-    'out/app/common/**/*',
-    '!**/*.ts'
-  ],
-  publish: [
-    'github',
-    {
-      provider: 'generic',
-      url: COMMON_APP_CONFIG.BASE_DOWNLOAD_URL
-    }
-  ],
-  generateUpdatesFilesForAllChannels: true,
-  nsis: {
-    // 指定guid，此guid会存放在注册表中，如果没有指定则系统会自动生成
-    guid: 'Postcat',
-    oneClick: false,
-    allowElevation: true,
-    allowToChangeInstallationDirectory: true,
-    // for win - 将协议写入主机的脚本
-    include: 'scripts/urlProtoco.nsh'
-  },
-  protocols: [
-    // for macOS - 用于在主机注册指定协议
-    {
-      name: 'eoapi',
-      schemes: ['eoapi']
-    }
-  ],
-  portable: {
-    splashImage: 'src/app/common/images/postcat.bmp'
-  },
-  dmg: {
-    sign: false
-  },
-  afterSign: 'scripts/notarize.js',
-  linux: {
-    icon: 'src/app/common/images/',
-    target: ['AppImage']
-  },
-  mac: {
-    icon: 'src/app/common/images/512x512.png',
-    hardenedRuntime: true,
-    category: 'public.app-category.productivity',
-    gatekeeperAssess: false,
-    entitlements: 'scripts/entitlements.mac.plist',
-    entitlementsInherit: 'scripts/entitlements.mac.plist',
-    target: [
-      {
-        target: 'default',
-        arch: ['x64', 'arm64']
-      }
-    ]
-  }
-};
+
 const config: Configuration = {
   ...ELECTRON_BUILD_CONFIG,
   win: {

--- a/scripts/buildNoSign.ts
+++ b/scripts/buildNoSign.ts
@@ -1,15 +1,14 @@
-import { sign, doSign } from 'app-builder-lib/out/codeSign/windowsCodeSign';
-import { build, BuildResult, Platform } from 'electron-builder';
+import { sign } from 'app-builder-lib/out/codeSign/windowsCodeSign';
 import type { Configuration } from 'electron-builder';
+import { Platform, build } from 'electron-builder';
 import minimist from 'minimist';
-import YAML from 'yaml';
 
 import pkgInfo from '../package.json';
-import { ELECTRON_BUILD_CONFIG } from './build';
+import { ELECTRON_BUILD_CONFIG } from './baseConfig';
 
 import { exec, spawn } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
-import path, { resolve } from 'node:path';
+import path from 'node:path';
 import { exit, platform } from 'node:process';
 
 const pkgPath = path.join(__dirname, '../package.json');


### PR DESCRIPTION
yarn run build:win:noSign
script error 'Cannot read properties of null (reading from)'
run two scripts build.ts and buildNoSign.ts
![image](https://github.com/Postcatlab/postcat/assets/30801141/4a9aef50-e19a-4a76-9885-d110d87c1bc9)

